### PR TITLE
Remove unnecessary import

### DIFF
--- a/lib/searchable_listview.dart
+++ b/lib/searchable_listview.dart
@@ -1,7 +1,6 @@
 // ignore_for_file: must_be_immutable
 
 import 'package:flutter/material.dart';
-import 'package:flutter/rendering.dart';
 import 'package:searchable_listview/resources/arrays.dart';
 
 class SearchableList<T> extends StatefulWidget {


### PR DESCRIPTION
Remove unnecessary import - all of the used elements are also provided by the import of `'package:flutter/material.dart'`.

This way, the package can pass the static analysis. 