### PR TITLE
Fix: pass text style to search field

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -54,6 +54,9 @@ class _ExampleAppState extends State<ExampleApp> {
             child: Padding(
               padding: const EdgeInsets.all(15),
               child: SearchableList<Actor>(
+                style: const TextStyle(
+                  fontSize: 25
+                ),
                 onPaginate: () async {
                   await Future.delayed(const Duration(milliseconds: 1000));
                   setState(() {

--- a/lib/searchable_listview.dart
+++ b/lib/searchable_listview.dart
@@ -336,6 +336,7 @@ class _SearchableListState<T> extends State<SearchableList<T>> {
                 textInputType: widget.textInputType,
                 displayClearIcon: widget.displayClearIcon,
                 defaultSuffixIconColor: widget.defaultSuffixIconColor,
+                textStyle: widget.style,
               ),
               const SizedBox(
                 height: 20,
@@ -364,6 +365,7 @@ class _SearchableListState<T> extends State<SearchableList<T>> {
                 textInputType: widget.textInputType,
                 displayClearIcon: widget.displayClearIcon,
                 defaultSuffixIconColor: widget.defaultSuffixIconColor,
+                textStyle: widget.style,
               ),
             ],
     );
@@ -451,6 +453,7 @@ class _SearchableListState<T> extends State<SearchableList<T>> {
                       textInputType: widget.textInputType,
                       displayClearIcon: widget.displayClearIcon,
                       defaultSuffixIconColor: widget.defaultSuffixIconColor,
+                      textStyle: widget.style,
                     ),
                     const SizedBox(
                       height: 10,
@@ -519,6 +522,7 @@ class _SearchableListState<T> extends State<SearchableList<T>> {
                       textInputType: widget.textInputType,
                       displayClearIcon: widget.displayClearIcon,
                       defaultSuffixIconColor: widget.defaultSuffixIconColor,
+                      textStyle: widget.style,
                     ),
                   ],
           )
@@ -541,6 +545,7 @@ class _SearchableListState<T> extends State<SearchableList<T>> {
                         textInputType: widget.textInputType,
                         displayClearIcon: widget.displayClearIcon,
                         defaultSuffixIconColor: widget.defaultSuffixIconColor,
+                        textStyle: widget.style
                       ),
                     ),
                     SliverList(
@@ -590,6 +595,7 @@ class _SearchableListState<T> extends State<SearchableList<T>> {
                         textInputType: widget.textInputType,
                         displayClearIcon: widget.displayClearIcon,
                         defaultSuffixIconColor: widget.defaultSuffixIconColor,
+                        textStyle: widget.style
                       ),
                     ),
                   ],

--- a/lib/widgets/serach_text_field.dart
+++ b/lib/widgets/serach_text_field.dart
@@ -14,6 +14,7 @@ class SearchTextField extends StatelessWidget {
   final Function(String)? onSubmitSearch;
   final bool displayClearIcon;
   final Color defaultSuffixIconColor;
+  final TextStyle? textStyle;
 
   const SearchTextField({
     Key? key,
@@ -29,6 +30,7 @@ class SearchTextField extends StatelessWidget {
     required this.textInputType,
     required this.displayClearIcon,
     required this.defaultSuffixIconColor,
+    required this.textStyle,
   }) : super(key: key);
 
   @override
@@ -39,6 +41,7 @@ class SearchTextField extends StatelessWidget {
       decoration: inputDecoration?.copyWith(
         suffix: inputDecoration?.suffix ?? _renderSuffixIcon(),
       ),
+      style: textStyle,
       controller: searchTextController,
       textInputAction: keyboardAction,
       keyboardType: textInputType,


### PR DESCRIPTION
Although searchable list had a style attribute it has never been passed to the search field. 

Now it is possible to change the color, font size etc of the search field. 