### PR TITLE
Fix SuffixIcon when displayClearIcon is false

### DIFF
--- a/lib/widgets/search_text_field.dart
+++ b/lib/widgets/search_text_field.dart
@@ -112,7 +112,8 @@ class SearchTextField extends StatelessWidget {
                           mainAxisAlignment: MainAxisAlignment.end,
                           mainAxisSize: MainAxisSize.min,
                           children: [
-                            (inputDecoration?.suffix ?? _renderSuffixIcon())!,
+                            (inputDecoration?.suffixIcon ??
+                                _renderSuffixIcon())!,
                             const SizedBox(
                               width: 5,
                             ),


### PR DESCRIPTION
When you have `displayClearIcon = false` the `SuffixIcon` is not being rendered if you have it set inside the `inputDecoration`.

This was previously working properly when you rendered `suffix: inputDecoration?.suffix ?? ....` but when it was changed in https://github.com/koukibadr/Searchable-Listview/commit/350b732e36cadd00f887b682bdac66774a4eebcf#diff-de12fbc2890289707d896e47132a56f44f6ccca62d32d2ad600de27eedd0c665L101-R135 it broke functionality.

Changing the line to `suffix: inputDecoration?.suffixIcon ?? ...` fixes the issue for my use case, but it might be better to change the code entirely to the TextField decoration Suffix instead of Suffix Icon (the parent widget)

If I'm not clear enough or if you think there is a better way to solve this issue let me know 😄