### PR TITLE
Trigger widget rebuild when calling onPaginate callback

### DIFF
--- a/lib/searchable_listview.dart
+++ b/lib/searchable_listview.dart
@@ -475,7 +475,9 @@ class _SearchableListState<T> extends State<SearchableList<T>> {
       if (widget.onPaginate != null &&
           scrollController.position.pixels ==
               scrollController.position.maxScrollExtent) {
-        widget.onPaginate?.call();
+        setState(() {
+          widget.onPaginate?.call();
+        });
       }
     });
     widget.searchTextController?.addListener(() {


### PR DESCRIPTION
When calling the onPaginate callback, trigger a widget rebuild to ensure the list view can update its state to reflect new data changes.