### PR TITLE
Fix #118: catch expansion list filtering error

### DIFF
--- a/lib/searchable_listview.dart
+++ b/lib/searchable_listview.dart
@@ -965,10 +965,11 @@ class _SearchableListState<T> extends State<SearchableList<T>> {
         widget.expansionListData =
             widget.filterExpansionData?.call(value) ?? {};
       });
-      expansionTileControllers.every((controller) {
-        controller.expand();
-        return true;
-      });
+      for (var controller in expansionTileControllers) {
+        try {
+          controller.expand();
+        } catch (e) {} 
+      }
     } else if (widget.asyncListCallback != null) {
       setState(() {
         filtredAsyncListResult = widget.asyncListFilter!(


### PR DESCRIPTION
- `controller.expand()` throws an error when filtering items because controller.state is null when the ExpansionTileController is not in the list `controller.state` is null