### PR TITLE
Render Suffix Widget with InputDecoration

### DIFF
--- a/lib/widgets/search_text_field.dart
+++ b/lib/widgets/search_text_field.dart
@@ -109,8 +109,11 @@ class SearchTextField extends StatelessWidget {
                   textAlign: textAlign,
                   focusNode: focusNode,
                   enabled: searchFieldEnabled,
-                  decoration: (inputDecoration ??
-                      const InputDecoration()
+                  decoration: (inputDecoration != null
+                      ? inputDecoration!.copyWith(
+                          suffix: renderSuffixWidget(context),
+                        )
+                      : const InputDecoration()
                           .copyWith(suffix: renderSuffixWidget(context))),
                   style: textStyle,
                   controller: searchTextController,


### PR DESCRIPTION
Allow user to style the inputDecoration of the search text field and show the Suffix Widgets to clear and sort the list using default constructor.