### PR TITLE
Fix: asyncListCallback called at initState

### DIFF
--- a/example/lib/widgets/async_searchable_listview.dart
+++ b/example/lib/widgets/async_searchable_listview.dart
@@ -20,7 +20,7 @@ class AsyncSearchableListview extends StatelessWidget {
       },
       asyncListFilter: (query, list) async {
         await Future.delayed(const Duration(seconds: 3));
-        var result = actors
+        var result = list
             .where((element) =>
                 element.name.contains(query) ||
                 element.lastName.contains(query))

--- a/lib/searchable_listview.dart
+++ b/lib/searchable_listview.dart
@@ -519,6 +519,7 @@ class _SearchableListState<T> extends State<SearchableList<T>> {
   CancelableOperation<List<T>?>? _activeOperation;
   late Debouncer? _debouncer;
   List<ExpansionTileController> expansionTileControllers = [];
+  bool isAsyncCallBackRunning = true;
 
   @override
   void initState() {
@@ -541,7 +542,7 @@ class _SearchableListState<T> extends State<SearchableList<T>> {
     if (widget.asyncListCallback != null) {
       // Load the initial list for the async constructor
       WidgetsBinding.instance.addPostFrameCallback((_) async {
-        _asyncFilter("");
+        await _asyncInitialList();
         if (mounted) setState(() {});
       });
       _debouncer = Debouncer(milliseconds: widget.asyncDebounceTime);
@@ -612,7 +613,7 @@ class _SearchableListState<T> extends State<SearchableList<T>> {
     if (asyncError) {
       return widget.errorWidget ?? const DefaultErrorWidget();
     }
-    if (_activeOperation != null) {
+    if (_activeOperation != null || isAsyncCallBackRunning) {
       return widget.loadingWidget ?? const DefaultLoadingWidget();
     }
     return renderSearchableListView();
@@ -799,8 +800,9 @@ class _SearchableListState<T> extends State<SearchableList<T>> {
     } else if (widget.asyncListCallback != null) {
       // Debouncer always has a value in this case
       _debouncer!.run(() async {
+        if (mounted) setState(() {});
         _activeOperation?.cancel();
-        _asyncFilter(value);
+        await _asyncFilter(value);
         if (mounted) setState(() {});
       });
     } else {
@@ -862,6 +864,11 @@ class _SearchableListState<T> extends State<SearchableList<T>> {
   }
 
   Future<void> _asyncFilter(String value) async {
+    if (isAsyncCallBackRunning) {
+      // Wait for the initial list before filtering
+      return;
+    }
+
     final operation = CancelableOperation.fromFuture(
       widget.asyncListFilter!(
         value,
@@ -879,11 +886,34 @@ class _SearchableListState<T> extends State<SearchableList<T>> {
         asyncError = true;
       }
     } finally {
-      // Make sure to not interrupt an other operation
+      // Make sure to not interrupt another operation
       if (_activeOperation == operation) {
         _activeOperation = null;
       }
     }
-    setState(() {});
+  }
+
+  Future<void> _asyncInitialList() async {
+    isAsyncCallBackRunning = true;
+    // First get the initial list
+    try {
+      final initialData = await widget.asyncListCallback!();
+      if (initialData != null) {
+        asyncListResult = initialData;
+      }
+    } catch (e) {
+      setState(() {
+        asyncError = true;
+      });
+      return;
+    }
+    isAsyncCallBackRunning = false;
+    // Then check if a query was typed during the initial list loading to filter if needed
+    if ((widget.searchTextController?.text ?? "") != "") {
+      await _asyncFilter(widget.searchTextController!.text);
+    } else {
+      filtredAsyncListResult.clear();
+      filtredAsyncListResult.addAll(asyncListResult);
+    }
   }
 }

--- a/lib/searchable_listview.dart
+++ b/lib/searchable_listview.dart
@@ -900,11 +900,11 @@ class _SearchableListState<T> extends State<SearchableList<T>> {
       final initialData = await widget.asyncListCallback!();
       if (initialData != null) {
         asyncListResult = initialData;
+      } else {
+        asyncError = true;
       }
     } catch (e) {
-      setState(() {
-        asyncError = true;
-      });
+      asyncError = true;
       return;
     }
     isAsyncCallBackRunning = false;


### PR DESCRIPTION
Closes #179.

The SearchableList.async now stores the asyncListCallback result and transmit it as an argument of asyncListFilter as expected.
The example is updated to show this behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed searchable list filtering so it operates on the currently provided data set rather than a stale static reference.
  * Improved async loading and search flow: the component now shows loading during initial fetch, prevents filtering until initial data is ready, and handles concurrent operations more reliably.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/koukibadr/Searchable-Listview/pull/180?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->